### PR TITLE
Add SubRouters functionality to support route contextual types

### DIFF
--- a/fernet.go
+++ b/fernet.go
@@ -21,6 +21,14 @@ type (
 		initT      func(RequestContext) T
 	}
 
+	// Registerable is an interface that can be implemented by types that want
+	// to register routes with a router. This allows the router to be extended
+	// by internal or external packages like Group, and SubRouter.
+	Registerable[T RequestContext] interface {
+		// RawMatch registers a route with the given method and path
+		RawMatch(method string, path string, fn Handler[T])
+	}
+
 	// Routable is an interface that can be implemented by types that want to
 	// register routes with a router.
 	Routable[T RequestContext] interface {
@@ -63,6 +71,12 @@ func New[T RequestContext, Init func(RequestContext) T](init Init) *Router[T] {
 	r.metal = NewMetalStack[T](http.HandlerFunc(r.handler))
 
 	return r
+}
+
+// RawMatch implements the Registerable interface and registers a route with the
+// router.
+func (r *Router[T]) RawMatch(method string, path string, handler Handler[T]) {
+	r.Match(method, path, handler)
 }
 
 // Match registers a route with the router.

--- a/subrouter.go
+++ b/subrouter.go
@@ -2,7 +2,6 @@ package fernet
 
 import (
 	"context"
-	"net/http"
 )
 
 type (
@@ -76,27 +75,27 @@ func (r *SubRouter[T, RequestData]) Match(method string, path string, fn SubRout
 
 // Get registers a GET handler with the given path.
 func (r *SubRouter[T, RequestData]) Get(path string, fn SubRouterHandler[T, RequestData]) {
-	r.Match(http.MethodGet, path, fn)
+	r.root.Get(path, fn)
 }
 
 // Post registers a POST handler with the given path.
 func (r *SubRouter[T, RequestData]) Post(path string, fn SubRouterHandler[T, RequestData]) {
-	r.Match(http.MethodPost, path, fn)
+	r.root.Post(path, fn)
 }
 
 // Put registers a PUT handler with the given path.
 func (r *SubRouter[T, RequestData]) Put(path string, fn SubRouterHandler[T, RequestData]) {
-	r.Match(http.MethodPut, path, fn)
+	r.root.Put(path, fn)
 }
 
 // Patch registers a PATCH handler with the given path.
 func (r *SubRouter[T, RequestData]) Patch(path string, fn SubRouterHandler[T, RequestData]) {
-	r.Match(http.MethodPatch, path, fn)
+	r.root.Patch(path, fn)
 }
 
 // Delete registers a DELETE handler with the given path.
 func (r *SubRouter[T, RequestData]) Delete(path string, fn SubRouterHandler[T, RequestData]) {
-	r.Match(http.MethodDelete, path, fn)
+	r.root.Delete(path, fn)
 }
 
 // Use registers a middleware function that will be called before each handler.

--- a/subrouter.go
+++ b/subrouter.go
@@ -18,28 +18,25 @@ type (
 	// SubRouter is similar to fernet.Router, but accepts a type that implements
 	// the FromRequest interface that will be initialized each request and passed
 	// to the handler as the third argument.
-	SubRouter[T RequestContext, Child FromRequest[T]] struct {
-		parent     Registerable[T]
-		root       *SubRouterGroup[T, Child]
-		middleware []func(context.Context, T, Handler[T])
+	SubRouter[T RequestContext, RequestData FromRequest[T]] struct {
+		parent Registerable[T]
+		root   *SubRouterGroup[T, RequestData]
 	}
 
 	// SubRouterHandler is the signature for SubRouter handlers. It accepts the
 	// standard context.Context, and T RequestContext, but also a third argument
 	// that implements the FromRequest interface.
-	SubRouterHandler[T RequestContext, Child FromRequest[T]] func(context.Context, T, Child)
+	SubRouterHandler[T RequestContext, RequestData FromRequest[T]] func(context.Context, T, RequestData)
 
 	// SubRouterRoutable ensures consistency across all SubRouter based types.
-	SubRouterRoutable[T RequestContext, Child FromRequest[T]] interface {
-		Match(string, string, SubRouterHandler[T, Child])
-		Get(string, SubRouterHandler[T, Child])
-		Post(string, SubRouterHandler[T, Child])
-		Put(string, SubRouterHandler[T, Child])
-		Patch(string, SubRouterHandler[T, Child])
-		Delete(string, SubRouterHandler[T, Child])
-
-		Use(func(context.Context, T, Handler[T]))
-		Group(string) *SubRouterGroup[T, Child]
+	SubRouterRoutable[T RequestContext, RequestData FromRequest[T]] interface {
+		Match(string, string, SubRouterHandler[T, RequestData])
+		Get(string, SubRouterHandler[T, RequestData])
+		Post(string, SubRouterHandler[T, RequestData])
+		Put(string, SubRouterHandler[T, RequestData])
+		Patch(string, SubRouterHandler[T, RequestData])
+		Delete(string, SubRouterHandler[T, RequestData])
+		Before(func(context.Context, T, RequestData) bool)
 	}
 
 	placeholderFromRequest struct{}
@@ -54,61 +51,60 @@ var _ SubRouterRoutable[*RootRequestContext, *placeholderFromRequest] = &SubRout
 // that accept a type that implements the FromRequest interface. Each request
 // will initialize a new instance of the type, call `FromRequest` on it, and
 // pass it to the handler if the method returns true.
-func NewSubRouter[Parent RequestContext, Child FromRequest[Parent]](r Registerable[Parent], dataType Child) *SubRouter[Parent, Child] {
-	return &SubRouter[Parent, Child]{
+func NewSubRouter[Parent RequestContext, RequestData FromRequest[Parent]](r Registerable[Parent], dataType RequestData) *SubRouter[Parent, RequestData] {
+	return &SubRouter[Parent, RequestData]{
 		parent: r,
-		root: &SubRouterGroup[Parent, Child]{
-			prefix:     "",
-			parent:     r,
-			middleware: make([]func(context.Context, Parent, Handler[Parent]), 0),
+		root: &SubRouterGroup[Parent, RequestData]{
+			prefix:  "",
+			parent:  r,
+			befores: make([]func(context.Context, Parent, RequestData) bool, 0),
 		},
-		middleware: make([]func(context.Context, Parent, Handler[Parent]), 0),
 	}
 }
 
 // RawMatch implements the Registerable interface and forwards the call to the
 // parent router. This allows subrouters and groups to be registered with the
 // subrouter.
-func (r *SubRouter[T, Child]) RawMatch(method string, path string, fn Handler[T]) {
+func (r *SubRouter[T, RequestData]) RawMatch(method string, path string, fn Handler[T]) {
 	r.parent.RawMatch(method, path, fn)
 }
 
 // Match registers the given handler with the given method and path.
-func (r *SubRouter[T, Child]) Match(method string, path string, fn SubRouterHandler[T, Child]) {
+func (r *SubRouter[T, RequestData]) Match(method string, path string, fn SubRouterHandler[T, RequestData]) {
 	r.root.Match(method, path, fn)
 }
 
 // Get registers a GET handler with the given path.
-func (r *SubRouter[T, Child]) Get(path string, fn SubRouterHandler[T, Child]) {
+func (r *SubRouter[T, RequestData]) Get(path string, fn SubRouterHandler[T, RequestData]) {
 	r.Match(http.MethodGet, path, fn)
 }
 
 // Post registers a POST handler with the given path.
-func (r *SubRouter[T, Child]) Post(path string, fn SubRouterHandler[T, Child]) {
+func (r *SubRouter[T, RequestData]) Post(path string, fn SubRouterHandler[T, RequestData]) {
 	r.Match(http.MethodPost, path, fn)
 }
 
 // Put registers a PUT handler with the given path.
-func (r *SubRouter[T, Child]) Put(path string, fn SubRouterHandler[T, Child]) {
+func (r *SubRouter[T, RequestData]) Put(path string, fn SubRouterHandler[T, RequestData]) {
 	r.Match(http.MethodPut, path, fn)
 }
 
 // Patch registers a PATCH handler with the given path.
-func (r *SubRouter[T, Child]) Patch(path string, fn SubRouterHandler[T, Child]) {
+func (r *SubRouter[T, RequestData]) Patch(path string, fn SubRouterHandler[T, RequestData]) {
 	r.Match(http.MethodPatch, path, fn)
 }
 
 // Delete registers a DELETE handler with the given path.
-func (r *SubRouter[T, Child]) Delete(path string, fn SubRouterHandler[T, Child]) {
+func (r *SubRouter[T, RequestData]) Delete(path string, fn SubRouterHandler[T, RequestData]) {
 	r.Match(http.MethodDelete, path, fn)
 }
 
 // Use registers a middleware function that will be called before each handler.
-func (r *SubRouter[T, Child]) Use(fn func(context.Context, T, Handler[T])) {
-	r.middleware = append(r.middleware, fn)
+func (r *SubRouter[T, RequestData]) Before(fn func(context.Context, T, RequestData) bool) {
+	r.root.Before(fn)
 }
 
 // Group returns a new SubRouterGroup with the given prefix.
-func (r *SubRouter[T, Child]) Group(prefix string) *SubRouterGroup[T, Child] {
+func (r *SubRouter[T, RequestData]) Group(prefix string) *SubRouterGroup[T, RequestData] {
 	return r.root.Group(prefix)
 }

--- a/subrouter.go
+++ b/subrouter.go
@@ -1,0 +1,114 @@
+package fernet
+
+import (
+	"context"
+	"net/http"
+)
+
+type (
+	// FromRequest enables a struct to be initialized from a RequestContext that
+	// will be passed to each handler. It accepts a context.Context and the
+	// generic RequestContext type.
+	//
+	// The request can be short-circuited by returning false from this function.
+	FromRequest[T RequestContext] interface {
+		FromRequest(context.Context, T) bool
+	}
+
+	// SubRouter is similar to fernet.Router, but accepts a type that implements
+	// the FromRequest interface that will be initialized each request and passed
+	// to the handler as the third argument.
+	SubRouter[T RequestContext, Child FromRequest[T]] struct {
+		parent     Registerable[T]
+		root       *SubRouterGroup[T, Child]
+		middleware []func(context.Context, T, Handler[T])
+	}
+
+	// SubRouterHandler is the signature for SubRouter handlers. It accepts the
+	// standard context.Context, and T RequestContext, but also a third argument
+	// that implements the FromRequest interface.
+	SubRouterHandler[T RequestContext, Child FromRequest[T]] func(context.Context, T, Child)
+
+	// SubRouterRoutable ensures consistency across all SubRouter based types.
+	SubRouterRoutable[T RequestContext, Child FromRequest[T]] interface {
+		Match(string, string, SubRouterHandler[T, Child])
+		Get(string, SubRouterHandler[T, Child])
+		Post(string, SubRouterHandler[T, Child])
+		Put(string, SubRouterHandler[T, Child])
+		Patch(string, SubRouterHandler[T, Child])
+		Delete(string, SubRouterHandler[T, Child])
+
+		Use(func(context.Context, T, Handler[T]))
+		Group(string) *SubRouterGroup[T, Child]
+	}
+
+	placeholderFromRequest struct{}
+)
+
+// Implement the FromRequest interface for the placeholder type so we can assert interface adherence.
+func (p *placeholderFromRequest) FromRequest(context.Context, *RootRequestContext) bool { return false }
+
+var _ SubRouterRoutable[*RootRequestContext, *placeholderFromRequest] = &SubRouter[*RootRequestContext, *placeholderFromRequest]{}
+
+// NewSubRouter creates a new subrouter that can be used to register handlers
+// that accept a type that implements the FromRequest interface. Each request
+// will initialize a new instance of the type, call `FromRequest` on it, and
+// pass it to the handler if the method returns true.
+func NewSubRouter[Parent RequestContext, Child FromRequest[Parent]](r Registerable[Parent], dataType Child) *SubRouter[Parent, Child] {
+	return &SubRouter[Parent, Child]{
+		parent: r,
+		root: &SubRouterGroup[Parent, Child]{
+			prefix:     "",
+			parent:     r,
+			middleware: make([]func(context.Context, Parent, Handler[Parent]), 0),
+		},
+		middleware: make([]func(context.Context, Parent, Handler[Parent]), 0),
+	}
+}
+
+// RawMatch implements the Registerable interface and forwards the call to the
+// parent router. This allows subrouters and groups to be registered with the
+// subrouter.
+func (r *SubRouter[T, Child]) RawMatch(method string, path string, fn Handler[T]) {
+	r.parent.RawMatch(method, path, fn)
+}
+
+// Match registers the given handler with the given method and path.
+func (r *SubRouter[T, Child]) Match(method string, path string, fn SubRouterHandler[T, Child]) {
+	r.root.Match(method, path, fn)
+}
+
+// Get registers a GET handler with the given path.
+func (r *SubRouter[T, Child]) Get(path string, fn SubRouterHandler[T, Child]) {
+	r.Match(http.MethodGet, path, fn)
+}
+
+// Post registers a POST handler with the given path.
+func (r *SubRouter[T, Child]) Post(path string, fn SubRouterHandler[T, Child]) {
+	r.Match(http.MethodPost, path, fn)
+}
+
+// Put registers a PUT handler with the given path.
+func (r *SubRouter[T, Child]) Put(path string, fn SubRouterHandler[T, Child]) {
+	r.Match(http.MethodPut, path, fn)
+}
+
+// Patch registers a PATCH handler with the given path.
+func (r *SubRouter[T, Child]) Patch(path string, fn SubRouterHandler[T, Child]) {
+	r.Match(http.MethodPatch, path, fn)
+}
+
+// Delete registers a DELETE handler with the given path.
+func (r *SubRouter[T, Child]) Delete(path string, fn SubRouterHandler[T, Child]) {
+	r.Match(http.MethodDelete, path, fn)
+}
+
+// Use registers a middleware function that will be called before each handler.
+func (r *SubRouter[T, Child]) Use(fn func(context.Context, T, Handler[T])) {
+	r.middleware = append(r.middleware, fn)
+}
+
+// Group returns a new SubRouterGroup with the given prefix.
+func (r *SubRouter[T, Child]) Group(prefix string) *SubRouterGroup[T, Child] {
+	return r.root.Group(prefix)
+}

--- a/subrouter_group.go
+++ b/subrouter_group.go
@@ -79,7 +79,6 @@ func (r *SubRouterGroup[T, Child]) wrap(fn SubRouterHandler[T, Child]) Handler[T
 	return func(ctx context.Context, rc T) {
 		newChild := reflect.New(childType)
 		if !isPointer {
-			// TODO report warning?
 			newChild = newChild.Elem()
 		}
 		child := newChild.Interface()

--- a/subrouter_group.go
+++ b/subrouter_group.go
@@ -53,7 +53,9 @@ func (r *SubRouterGroup[T, RequestData]) Delete(path string, fn SubRouterHandler
 	r.Match(http.MethodDelete, path, fn)
 }
 
-// Use registers a befores function that will be called before each handler.
+// Before registers a befores function that will be called before each handler.
+// If the function returns false, the subsequent befores and the handler will
+// not be called.
 func (r *SubRouterGroup[T, RequestData]) Before(fn func(context.Context, T, RequestData) bool) {
 	r.befores = append(r.befores, fn)
 }

--- a/subrouter_group.go
+++ b/subrouter_group.go
@@ -7,11 +7,10 @@ import (
 )
 
 // SubRouterGroup is a group of routes from a SubRouter that share a common
-// prefix and maintain their own middleware stack.
-type SubRouterGroup[T RequestContext, Child FromRequest[T]] struct {
-	prefix     string
-	parent     Registerable[T]
-	middleware []func(context.Context, T, Handler[T])
+type SubRouterGroup[T RequestContext, RequestData FromRequest[T]] struct {
+	prefix  string
+	parent  Registerable[T]
+	befores []func(context.Context, T, RequestData) bool
 }
 
 var _ SubRouterRoutable[*RootRequestContext, *placeholderFromRequest] = &SubRouter[*RootRequestContext, *placeholderFromRequest]{}
@@ -19,75 +18,75 @@ var _ SubRouterRoutable[*RootRequestContext, *placeholderFromRequest] = &SubRout
 // RawMatch implements the Registerable interface and forwards the call to the
 // parent router. This allows subrouters and groups to be registered with the
 // subrouter.
-func (r *SubRouterGroup[T, Child]) RawMatch(method string, path string, fn Handler[T]) {
+func (r *SubRouterGroup[T, RequestData]) RawMatch(method string, path string, fn Handler[T]) {
 	r.parent.RawMatch(method, path, fn)
 }
 
 // Match registers the given handler with the given method and path.
-func (r *SubRouterGroup[T, Child]) Match(method string, path string, fn SubRouterHandler[T, Child]) {
+func (r *SubRouterGroup[T, RequestData]) Match(method string, path string, fn SubRouterHandler[T, RequestData]) {
 	r.parent.RawMatch(method, path, r.wrap(fn))
 }
 
 // Get registers a GET handler with the given path.
-func (r *SubRouterGroup[T, Child]) Get(path string, fn SubRouterHandler[T, Child]) {
+func (r *SubRouterGroup[T, RequestData]) Get(path string, fn SubRouterHandler[T, RequestData]) {
 	r.Match(http.MethodGet, path, fn)
 }
 
 // Post registers a POST handler with the given path.
-func (r *SubRouterGroup[T, Child]) Post(path string, fn SubRouterHandler[T, Child]) {
+func (r *SubRouterGroup[T, RequestData]) Post(path string, fn SubRouterHandler[T, RequestData]) {
 	r.Match(http.MethodPost, path, fn)
 }
 
 // Put registers a PUT handler with the given path.
-func (r *SubRouterGroup[T, Child]) Put(path string, fn SubRouterHandler[T, Child]) {
+func (r *SubRouterGroup[T, RequestData]) Put(path string, fn SubRouterHandler[T, RequestData]) {
 	r.Match(http.MethodPut, path, fn)
 }
 
 // Patch registers a PATCH handler with the given path.
-func (r *SubRouterGroup[T, Child]) Patch(path string, fn SubRouterHandler[T, Child]) {
+func (r *SubRouterGroup[T, RequestData]) Patch(path string, fn SubRouterHandler[T, RequestData]) {
 	r.Match(http.MethodPatch, path, fn)
 }
 
 // Delete registers a DELETE handler with the given path.
-func (r *SubRouterGroup[T, Child]) Delete(path string, fn SubRouterHandler[T, Child]) {
+func (r *SubRouterGroup[T, RequestData]) Delete(path string, fn SubRouterHandler[T, RequestData]) {
 	r.Match(http.MethodDelete, path, fn)
 }
 
-// Use registers a middleware function that will be called before each handler.
-func (r *SubRouterGroup[T, Child]) Use(fn func(context.Context, T, Handler[T])) {
-	r.middleware = append(r.middleware, fn)
+// Use registers a befores function that will be called before each handler.
+func (r *SubRouterGroup[T, RequestData]) Before(fn func(context.Context, T, RequestData) bool) {
+	r.befores = append(r.befores, fn)
 }
 
 // Group returns a new SubRouterGroup with the given prefix.
-func (r *SubRouterGroup[T, Child]) Group(prefix string) *SubRouterGroup[T, Child] {
-	return &SubRouterGroup[T, Child]{
-		prefix:     r.prefix + prefix,
-		parent:     r,
-		middleware: make([]func(context.Context, T, Handler[T]), 0),
+func (r *SubRouterGroup[T, RequestData]) Group(prefix string) *SubRouterGroup[T, RequestData] {
+	return &SubRouterGroup[T, RequestData]{
+		prefix:  r.prefix + prefix,
+		parent:  r,
+		befores: make([]func(context.Context, T, RequestData) bool, 0),
 	}
 }
 
-func (r *SubRouterGroup[T, Child]) wrap(fn SubRouterHandler[T, Child]) Handler[T] {
-	var t Child
-	childType := reflect.TypeOf(t)
-	isPointer := childType.Kind() == reflect.Ptr
+func (r *SubRouterGroup[T, RequestData]) wrap(fn SubRouterHandler[T, RequestData]) Handler[T] {
+	var t RequestData
+	requestDataType := reflect.TypeOf(t)
+	isPointer := requestDataType.Kind() == reflect.Ptr
 
 	if isPointer {
-		childType = childType.Elem()
+		requestDataType = requestDataType.Elem()
 	}
 
 	return func(ctx context.Context, rc T) {
-		newChild := reflect.New(childType)
+		newRequestData := reflect.New(requestDataType)
 		if !isPointer {
-			newChild = newChild.Elem()
+			newRequestData = newRequestData.Elem()
 		}
-		child := newChild.Interface()
-		success := (child).(FromRequest[T]).FromRequest(ctx, rc)
+		requestData := newRequestData.Interface()
+		success := (requestData).(FromRequest[T]).FromRequest(ctx, rc)
 
 		if !success {
 			return
 		}
 
-		fn(ctx, rc, child.(Child))
+		fn(ctx, rc, requestData.(RequestData))
 	}
 }

--- a/subrouter_group.go
+++ b/subrouter_group.go
@@ -1,0 +1,94 @@
+package fernet
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+)
+
+// SubRouterGroup is a group of routes from a SubRouter that share a common
+// prefix and maintain their own middleware stack.
+type SubRouterGroup[T RequestContext, Child FromRequest[T]] struct {
+	prefix     string
+	parent     Registerable[T]
+	middleware []func(context.Context, T, Handler[T])
+}
+
+var _ SubRouterRoutable[*RootRequestContext, *placeholderFromRequest] = &SubRouter[*RootRequestContext, *placeholderFromRequest]{}
+
+// RawMatch implements the Registerable interface and forwards the call to the
+// parent router. This allows subrouters and groups to be registered with the
+// subrouter.
+func (r *SubRouterGroup[T, Child]) RawMatch(method string, path string, fn Handler[T]) {
+	r.parent.RawMatch(method, path, fn)
+}
+
+// Match registers the given handler with the given method and path.
+func (r *SubRouterGroup[T, Child]) Match(method string, path string, fn SubRouterHandler[T, Child]) {
+	r.parent.RawMatch(method, path, r.wrap(fn))
+}
+
+// Get registers a GET handler with the given path.
+func (r *SubRouterGroup[T, Child]) Get(path string, fn SubRouterHandler[T, Child]) {
+	r.Match(http.MethodGet, path, fn)
+}
+
+// Post registers a POST handler with the given path.
+func (r *SubRouterGroup[T, Child]) Post(path string, fn SubRouterHandler[T, Child]) {
+	r.Match(http.MethodPost, path, fn)
+}
+
+// Put registers a PUT handler with the given path.
+func (r *SubRouterGroup[T, Child]) Put(path string, fn SubRouterHandler[T, Child]) {
+	r.Match(http.MethodPut, path, fn)
+}
+
+// Patch registers a PATCH handler with the given path.
+func (r *SubRouterGroup[T, Child]) Patch(path string, fn SubRouterHandler[T, Child]) {
+	r.Match(http.MethodPatch, path, fn)
+}
+
+// Delete registers a DELETE handler with the given path.
+func (r *SubRouterGroup[T, Child]) Delete(path string, fn SubRouterHandler[T, Child]) {
+	r.Match(http.MethodDelete, path, fn)
+}
+
+// Use registers a middleware function that will be called before each handler.
+func (r *SubRouterGroup[T, Child]) Use(fn func(context.Context, T, Handler[T])) {
+	r.middleware = append(r.middleware, fn)
+}
+
+// Group returns a new SubRouterGroup with the given prefix.
+func (r *SubRouterGroup[T, Child]) Group(prefix string) *SubRouterGroup[T, Child] {
+	return &SubRouterGroup[T, Child]{
+		prefix:     r.prefix + prefix,
+		parent:     r,
+		middleware: make([]func(context.Context, T, Handler[T]), 0),
+	}
+}
+
+func (r *SubRouterGroup[T, Child]) wrap(fn SubRouterHandler[T, Child]) Handler[T] {
+	var t Child
+	childType := reflect.TypeOf(t)
+	isPointer := childType.Kind() == reflect.Ptr
+
+	if isPointer {
+		childType = childType.Elem()
+	}
+
+	return func(ctx context.Context, rc T) {
+		newChild := reflect.New(childType)
+		if !isPointer {
+			// TODO report warning?
+			newChild = newChild.Elem()
+		}
+		child := newChild.Interface()
+		success := (child).(FromRequest[T]).FromRequest(ctx, rc)
+
+		if !success {
+			return
+		}
+
+		fn(ctx, rc, child.(Child))
+	}
+}

--- a/subrouter_group.go
+++ b/subrouter_group.go
@@ -7,6 +7,7 @@ import (
 )
 
 // SubRouterGroup is a group of routes from a SubRouter that share a common
+// prefix and maintain their own befores stack.
 type SubRouterGroup[T RequestContext, RequestData FromRequest[T]] struct {
 	prefix  string
 	parent  Registerable[T]
@@ -85,6 +86,12 @@ func (r *SubRouterGroup[T, RequestData]) wrap(fn SubRouterHandler[T, RequestData
 
 		if !success {
 			return
+		}
+
+		for _, before := range r.befores {
+			if !before(ctx, rc, requestData.(RequestData)) {
+				return
+			}
 		}
 
 		fn(ctx, rc, requestData.(RequestData))

--- a/subrouter_test.go
+++ b/subrouter_test.go
@@ -1,0 +1,109 @@
+package fernet
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type PostData struct {
+	ID int
+}
+
+func (p *PostData) FromRequest(ctx context.Context, r *RootRequestContext) bool {
+	p.ID = 1
+	return true
+}
+
+type CommentData struct {
+	ID int
+}
+
+func (c *CommentData) FromRequest(ctx context.Context, r *RootRequestContext) bool {
+	stringID := r.Params()["id"]
+	id, err := strconv.Atoi(stringID)
+	if err != nil {
+		r.Response().WriteHeader(http.StatusBadRequest)
+		return false
+	}
+
+	c.ID = id
+	return true
+}
+
+func TestSubRouter(t *testing.T) {
+	router := New(WithBasicRequestContext)
+
+	subrouter := NewSubRouter(router, &PostData{})
+	subrouter.Match("GET", "/", func(ctx context.Context, r *RootRequestContext, p *PostData) {
+		r.Response().Header().Set("Content-Type", "application/json")
+		r.Response().WriteHeader(http.StatusCreated)
+		_, _ = r.Response().Write([]byte(fmt.Sprintf(`{"id": "%d"}`, p.ID)))
+	})
+
+	require.Equal(t, 1, len(router.routes))
+	require.Equal(t, "GET", router.routes[0].Method)
+	require.Equal(t, "/", router.routes[0].Path)
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+
+	router.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusCreated, res.Code)
+	require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+	require.Equal(t, `{"id": "1"}`, res.Body.String())
+}
+
+func Test_SubRouterSubRouter(t *testing.T) {
+	router := New(WithBasicRequestContext)
+
+	subrouter := NewSubRouter(router, &PostData{})
+	subsubrouter := NewSubRouter(subrouter, &CommentData{})
+
+	subsubrouter.Match("GET", "/comments/:id", func(ctx context.Context, r *RootRequestContext, c *CommentData) {
+		r.Response().Header().Set("Content-Type", "application/json")
+		r.Response().WriteHeader(http.StatusCreated)
+		_, _ = r.Response().Write([]byte(fmt.Sprintf(`{"id": "%d"}`, c.ID)))
+	})
+
+	require.Equal(t, 1, len(router.routes))
+	require.Equal(t, "GET", router.routes[0].Method)
+	require.Equal(t, "/comments/:id", router.routes[0].Path)
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/comments/4", nil)
+
+	router.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusCreated, res.Code)
+	require.Equal(t, "application/json", res.Header().Get("Content-Type"))
+	require.Equal(t, `{"id": "4"}`, res.Body.String())
+}
+
+func Test_FromRequestFalse(t *testing.T) {
+	router := New(WithBasicRequestContext)
+
+	subrouter := NewSubRouter(router, &CommentData{})
+	subrouter.Match("GET", "/comments/:id", func(ctx context.Context, r *RootRequestContext, p *CommentData) {
+		r.Response().Header().Set("Content-Type", "application/json")
+		r.Response().WriteHeader(http.StatusCreated)
+		_, _ = r.Response().Write([]byte(fmt.Sprintf(`{"id": "%d"}`, p.ID)))
+	})
+
+	require.Equal(t, 1, len(router.routes))
+	require.Equal(t, "GET", router.routes[0].Method)
+	require.Equal(t, "/comments/:id", router.routes[0].Path)
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/comments/wow", nil)
+
+	router.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusBadRequest, res.Code)
+}


### PR DESCRIPTION
This adds a new type, SubRouter that allows route contextual types to be
instantiated per-request and passed to handlers. This enables greater
type safety in the routing layer.

e.g.

```go
router := fernet.New(func(ctx fernet.RequestContext) *AppRequestContext {
	return &RootRequestContext{
		// ...
	}
})

type TeamData struct {
	Team *Team
}

func (t *TeamData) FromRequest(ctx context.Context, rc *AppRequestContext) bool {
	team, err := rc.TeamRepository.FindBySlug(rc.Params["team_slug"])
	// If we can't find the team, do not call the handler and return a 404.
	if err != nil {
		rc.Render404()
		return false
	}

	// Check authorization
	if !rc.TeamRepository.IsMember(team, rc.CurrentUser) {
		rc.Render403()
		return false
	}

	t.Team = team
	// Call the handler
	return true
}

subrouter := fernet.NewSubRouter(router, &SubRequestContext{})
subrouter.Get("/teams/:team_slug", func(ctx context.Context, rc *AppRequestContext, td *TeamData) {
	// td.Team is now available
	rc.Render("team.html", map[string]interface{}{
		"team": td.Team,
	})
})
```
