### PR TITLE
Better subgroup support, fixes, validations

### DIFF
--- a/fernet.go
+++ b/fernet.go
@@ -58,6 +58,7 @@ type (
 )
 
 var _ Routable[*RootRequestContext] = (*Router[*RootRequestContext])(nil)
+var _ Registerable[*RootRequestContext] = (*Router[*RootRequestContext])(nil)
 
 // New returns a new router with the given RequestContext type. The function
 // passed to this function is used to initialize the RequestContext for each

--- a/fernet_test.go
+++ b/fernet_test.go
@@ -183,6 +183,15 @@ func TestRouter_Params(t *testing.T) {
 	require.Equal(t, "Hello fox", res.Body.String())
 }
 
+func TestRouter_UseAfterRoute(t *testing.T) {
+	router := New(WithBasicRequestContext)
+
+	router.Get("/hello", func(ctx context.Context, r *RootRequestContext) {})
+	require.PanicsWithValue(t, "Use can only be called before routes are defined", func() {
+		router.Use(func(ctx context.Context, r *RootRequestContext, next Handler[*RootRequestContext]) {})
+	})
+}
+
 func WithBasicRequestContext(rctx RequestContext) *RootRequestContext {
 	return rctx.(*RootRequestContext)
 }

--- a/subrouter_group.go
+++ b/subrouter_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"reflect"
+	"strings"
 )
 
 // subRouterGroup is a group of routes from a SubRouter that share a common
@@ -20,11 +21,13 @@ var _ SubRouterRoutable[*RootRequestContext, *placeholderFromRequest] = &SubRout
 // parent router. This allows subrouters and groups to be registered with the
 // subrouter.
 func (r *subRouterGroup[T, RequestData]) RawMatch(method string, path string, fn Handler[T]) {
+	path = strings.TrimSuffix(r.prefix, "/") + "/" + strings.TrimPrefix(path, "/")
 	r.parent.RawMatch(method, path, fn)
 }
 
 // Match registers the given handler with the given method and path.
 func (r *subRouterGroup[T, RequestData]) Match(method string, path string, fn SubRouterHandler[T, RequestData]) {
+	path = strings.TrimSuffix(r.prefix, "/") + "/" + strings.TrimPrefix(path, "/")
 	r.parent.RawMatch(method, path, r.wrap(fn))
 }
 
@@ -56,7 +59,7 @@ func (r *subRouterGroup[T, RequestData]) Delete(path string, fn SubRouterHandler
 // Group returns a new SubRouterGroup with the given prefix.
 func (r *subRouterGroup[T, RequestData]) Group(prefix string) *subRouterGroup[T, RequestData] {
 	return &subRouterGroup[T, RequestData]{
-		prefix: r.prefix + prefix,
+		prefix: prefix,
 		parent: r,
 	}
 }

--- a/subrouter_test.go
+++ b/subrouter_test.go
@@ -144,3 +144,24 @@ func Test_FromRequestFalse(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, res.Code)
 }
+
+func Test_SubRouterGroupPrefix(t *testing.T) {
+	router := New(WithBasicRequestContext)
+
+	subrouter := NewSubRouter(router, &PostData{})
+	group := subrouter.Group("/comments")
+	group.RawMatch(http.MethodGet, "/testing", func(ctx context.Context, r *RootRequestContext) {})
+	subgroup := group.Group("/sub")
+	fmt.Println("HERE")
+	subgroup.Get("/get", func(ctx context.Context, r *RootRequestContext, p *PostData) {})
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/comments/testing", nil)
+	router.ServeHTTP(res, req)
+	require.Equal(t, http.StatusOK, res.Code)
+
+	res = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/comments/sub/get", nil)
+	router.ServeHTTP(res, req)
+	require.Equal(t, http.StatusOK, res.Code)
+}

--- a/subrouter_test.go
+++ b/subrouter_test.go
@@ -165,3 +165,64 @@ func Test_SubRouterGroupPrefix(t *testing.T) {
 	router.ServeHTTP(res, req)
 	require.Equal(t, http.StatusOK, res.Code)
 }
+
+type TrackingRequestContext struct {
+	Chain []string
+	RequestContext
+}
+
+func (t *TrackingRequestContext) AddToChain(s string) {
+	t.Chain = append(t.Chain, s)
+}
+
+type TrackingData struct{}
+
+func (t *TrackingData) FromRequest(ctx context.Context, r *TrackingRequestContext) bool {
+	r.AddToChain("FromRequest")
+	return true
+}
+
+func Test_SubRouterMiddleware(t *testing.T) {
+	var tracking *TrackingRequestContext
+	router := New(func(r RequestContext) *TrackingRequestContext {
+		tracking = &TrackingRequestContext{RequestContext: r, Chain: []string{"new"}}
+		return tracking
+	})
+
+	router.Use(func(ctx context.Context, r *TrackingRequestContext, next Handler[*TrackingRequestContext]) {
+		r.AddToChain("router use")
+		next(ctx, r)
+	})
+
+	group := router.Group("/comments")
+	group.Use(func(ctx context.Context, r *TrackingRequestContext, next Handler[*TrackingRequestContext]) {
+		r.AddToChain("group use")
+		next(ctx, r)
+	})
+	subrouter := NewSubRouter(group, &TrackingData{})
+	subrouter.Use(func(ctx context.Context, r *TrackingRequestContext, next Handler[*TrackingRequestContext]) {
+		r.AddToChain("subrouter use")
+		next(ctx, r)
+	})
+	subgroup := subrouter.Group("/sub")
+	subgroup.Use(func(ctx context.Context, r *TrackingRequestContext, next Handler[*TrackingRequestContext]) {
+		r.AddToChain("subgroup use")
+		next(ctx, r)
+	})
+	subgroup.Get("/best", func(ctx context.Context, r *TrackingRequestContext, p *TrackingData) {
+		r.AddToChain("handler")
+	})
+
+	req := httptest.NewRequest("GET", "/comments/sub/best", nil)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+
+	require.Equal(
+		t,
+		[]string{"new", "router use", "group use", "subrouter use", "subgroup use", "FromRequest", "handler"},
+		tracking.Chain,
+		"expected the middleware, FromRequest, and handlers to be called in order",
+	)
+}


### PR DESCRIPTION
This builds on the last PR adding subgroups by polishing up some of the behavior
and making the rest of the framework support subgroups. It also adds some
validations around when `Use` can be called.
