### PR TITLE
Add support for wildcard routes in the router

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,6 @@ func main() {
         return &RequestContext{RequestContext: r}
     })
 
-    // UseMetal is used to add Go http based middleware to the application.
-    app.UseMetal(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
-        // Do something before the request is handled.
-        next.ServeHTTP(w, r)
-        // Do something after the request is handled.
-    })
-
     // Use is used to add fernet based middleware to the application.
     app.Use(func(ctx context.Context, r *RequestContext, next fernet.Handler[RequestContext]) {
         // Do something before the request is handled.
@@ -48,9 +41,15 @@ func main() {
         // Do something after the request is handled.
     })
 
-    app.Get("/", func(ctx context.Context, r *RequestContext) {
-        r.WriteString(http.StatusOK, "Hello World!")
+    // Fernet routing uses : to define named parameters in the path. Wildcards are also supported via *.
+    app.Get("/hello/:name", func(ctx context.Context, r *RequestContext) {
+        r.WriteString(http.StatusOK, fmt.Sprintf("Hello %s", rc.Params()["name"]))
     })
+
+    // Handle 404s by defining a catch-all route.
+    app.Get("*", func(ctx context.Context, r *RequestContext) {
+        r.WriteString(http.StatusNotFound, "Not Found")
+    }
 
     app.ListenAndServe(":3200")
 }

--- a/fernet.go
+++ b/fernet.go
@@ -159,7 +159,7 @@ func (r *Router[T]) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		if !ok {
 			// This should never actually get hit in real code but would
 			// indicate a bug in the framework.
-			panic("route did not match request")
+			panic("route did not match request. this is a bug in fernet. please open an issue reporting this error and how to reproduce it.")
 		}
 	} else {
 		params = map[string]string{}

--- a/fernet_test.go
+++ b/fernet_test.go
@@ -155,6 +155,23 @@ func TestRouter_UseAfterRoute(t *testing.T) {
 	})
 }
 
+func TestRouter_Wildcard(t *testing.T) {
+	router := New(WithBasicRequestContext)
+
+	router.Get("*", func(ctx context.Context, r *RootRequestContext) {
+		fmt.Println(r.Params())
+		_, _ = r.Response().Write([]byte("Not found!"))
+		r.Response().WriteHeader(http.StatusNotFound)
+	})
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/hello", nil)
+	router.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusNotFound, res.Code)
+	require.Equal(t, "Not found!", res.Body.String())
+}
+
 func WithBasicRequestContext(rctx RequestContext) *RootRequestContext {
 	return rctx.(*RootRequestContext)
 }

--- a/internal/radical/radical.go
+++ b/internal/radical/radical.go
@@ -33,7 +33,7 @@ func New[T any]() *Node[T] {
 func (n *Node[T]) Add(segments []string, value T) {
 	currentSegment := n
 
-	for _, segment := range segments {
+	for i, segment := range segments {
 		if strings.HasPrefix(segment, ":") {
 			child, ok := currentSegment.children[":named"]
 
@@ -49,6 +49,26 @@ func (n *Node[T]) Add(segments []string, value T) {
 
 			currentSegment = currentSegment.children[":named"]
 			continue
+		}
+
+		if strings.HasPrefix(segment, "*") {
+			if i != len(segments)-1 {
+				panic("wildcard segments must be the last segment in a path")
+			}
+
+			_, ok := currentSegment.children["*"]
+			if ok {
+				panic("wildcard segments can only be used once in a path")
+			}
+
+			currentSegment.children["*"] = &Node[T]{
+				segment:  "*",
+				children: make(map[string]*Node[T], 0),
+			}
+
+			currentSegment = currentSegment.children["*"]
+
+			break
 		}
 
 		child, ok := currentSegment.children[segment]
@@ -74,7 +94,15 @@ func (n *Node[T]) Add(segments []string, value T) {
 // it returns false and the zero value of T.
 func (n *Node[T]) Value(segments []string) (bool, T) {
 	currentNode := n
+	var lastWildcard *Node[T]
+
 	for _, segment := range segments {
+		// hold onto the last wildcard node we've seen in case we need it later
+		// if routes don't match
+		if wildcard, ok := currentNode.children["*"]; ok {
+			lastWildcard = wildcard
+		}
+
 		child, ok := currentNode.children[segment]
 		if ok {
 			currentNode = child
@@ -83,6 +111,10 @@ func (n *Node[T]) Value(segments []string) (bool, T) {
 
 		child, ok = currentNode.children[":named"]
 		if !ok {
+			if lastWildcard != nil {
+				return true, lastWildcard.value
+			}
+
 			return false, reflect.Zero(reflect.TypeOf(n.value)).Interface().(T)
 		}
 
@@ -91,6 +123,10 @@ func (n *Node[T]) Value(segments []string) (bool, T) {
 
 	if currentNode.isSet {
 		return true, currentNode.value
+	}
+
+	if lastWildcard != nil {
+		return true, lastWildcard.value
 	}
 
 	return false, currentNode.value

--- a/internal/radical/radical_test.go
+++ b/internal/radical/radical_test.go
@@ -103,3 +103,38 @@ func TestNode_MultipleDynamicChildren(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, 2, value)
 }
+
+func TestNode_Wildcards(t *testing.T) {
+	root := radical.New[int]()
+
+	root.Add([]string{"foo", "*"}, 1)
+	root.Add([]string{"foo", "bar"}, 2)
+	root.Add([]string{"foo"}, 3)
+
+	ok, value := root.Value([]string{"foo", "bar"})
+	require.True(t, ok)
+	require.Equal(t, 2, value)
+
+	ok, value = root.Value([]string{"foo", "baz"})
+	require.True(t, ok)
+	require.Equal(t, 1, value)
+
+	ok, value = root.Value([]string{"foo"})
+	require.True(t, ok)
+	require.Equal(t, 3, value)
+}
+
+func TestNode_WildcardRoot(t *testing.T) {
+	root := radical.New[int]()
+
+	root.Add([]string{"*"}, 404)
+	root.Add([]string{"foo", "bar", ":name", "hi"}, 1)
+
+	ok, value := root.Value([]string{"foo", "bar", "Fox", "hi"})
+	require.True(t, ok)
+	require.Equal(t, 1, value)
+
+	ok, value = root.Value([]string{"foo", "bar", "Fox", "hi", "there"})
+	require.True(t, ok)
+	require.Equal(t, 404, value)
+}

--- a/internal/radical/radical_test.go
+++ b/internal/radical/radical_test.go
@@ -138,3 +138,10 @@ func TestNode_WildcardRoot(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, 404, value)
 }
+
+func TestWildcard_LastRoute(t *testing.T) {
+	root := radical.New[int]()
+	require.PanicsWithValue(t, "wildcard segments must be the last segment in a path", func() {
+		root.Add([]string{"foo", "*", "bar"}, 1)
+	})
+}

--- a/route.go
+++ b/route.go
@@ -28,6 +28,8 @@ func (r *route[C]) match(req *http.Request) (bool, map[string]string) {
 	for i, part := range r.parts {
 		if strings.HasPrefix(part, ":") {
 			params[part[1:]] = reqParts[i]
+		} else if strings.HasPrefix(part, "*") {
+			params[part[1:]] = strings.Join(reqParts[i:], "/")
 		} else if part != reqParts[i] {
 			return false, nil
 		}


### PR DESCRIPTION
This adds support for wildcards as the last part of a path in radical
(the trie library powering the router) and in fernet itself. This allows
for handling of routes like `/hello/*name` or 404s like `/*path`.

e.g.

```go
// Support routes like `/hello/Fox/Mulder` to output "hello Fox Mulder"
router.Get("/hello/*name", func(ctx context.Context, r *RootRequestContext) {
	name := strings.Split(r.Params()["name"], "/")
	formattedName := strings.Join(name, " ")
	_, _ = r.Response().Write([]byte("hello " + formattedName))
})

// Support 404s when routes are missing
router.Get("*", func(ctx context.Context, r *RootRequestContext) {
	_, _ = r.Response().Write([]byte("Not found!"))
	r.Response().WriteHeader(http.StatusNotFound)
})
```
